### PR TITLE
Fix twine metadata

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ pylint~=3.0
 
 # uploading to pypi
 build~=1.0
-twine~=4.0
+twine~=5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ author = DataTrails Inc.
 author_email = support@datatrails.ai
 description = DataTrails Examples
 long_description = file: README.md
+long_description_content_type = text/markdown
 url = https://github.com/datatrails/datatrails-samples
 license = MIT
 license_files = LICENSE


### PR DESCRIPTION
twine 4.0 is incompatible with python3.12.
(unable to publish package)
Upgrade twine and fix warnings.

[AB#9329](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9329)