### PR TITLE
Dev/paul/9572 add user agent partner id headers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Run integrity checks
       run: |
         export PYTHONPATH=samples:${PYTHONPATH}
+        scripts/version.sh
         pycodestyle --format=pylint archivist_samples
         python3 -m pylint archivist_samples
         black archivist_samples

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ specify the archivist endpoint:
 export TEST_ARCHIVIST="https://app.datatrails.ai"
 export TEST_AUTHTOKEN_FILENAME=credentials/.auth_token
 export TEST_NAMESPACE="unique label"
+export TEST_PARTNER_ID="acmecorp"
 export TEST_VERBOSE=-v
 ```
 
@@ -44,6 +45,7 @@ Windows using Powershell - at the command prompt set values for environment vari
 $Env:TEST_ARCHIVIST="https://app.datatrails.ai"
 $Env:TEST_AUTHTOKEN_FILENAME = '<path of token location>'
 $Env:TEST_NAMESPACE = Get-Date -UFormat %s
+$Env:TEST_PARTNER_ID = 'acmecorp'
 $Env:TEST_VERBOSE = '-v'
 ```
 
@@ -70,7 +72,7 @@ All examples use a common set of arguments:
 
 ```bash
 export AUTH="-u $TEST_ARCHIVIST -t $TEST_AUTHTOKEN_FILENAME $TEST_VERBOSE"
-export ARGS="$AUTH --namespace $TEST_NAMESPACE"
+export ARGS="$AUTH --namespace $TEST_NAMESPACE --partner_id=$TEST_PARTNER_ID"
 ```
 
 ### Door Entry Control

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,6 +73,6 @@ tasks:
 
   wheel:
     desc: Builds python wheel package
-    deps: [about, clean]
+    deps: [about]
     cmds:
       - ./scripts/api.sh ./scripts/wheel.sh

--- a/archivist_samples/testing/archivist_parser.py
+++ b/archivist_samples/testing/archivist_parser.py
@@ -16,6 +16,9 @@ from sys import exit as sys_exit
 from archivist.archivist import Archivist
 from archivist.logger import set_logger
 
+from ..about import __version__ as VERSION
+from .constants import USER_AGENT_PREFIX
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -81,6 +84,15 @@ def common_parser(description):
         required=True,
         help="FILE containing API authentication token",
     )
+    parser.add_argument(
+        "-p",
+        "--partner_id",
+        type=str,
+        dest="partner_id",
+        action="store",
+        default="",
+        help="partner id",
+    )
 
     return parser
 
@@ -98,7 +110,12 @@ def endpoint(args):
         with open(args.auth_token_file, mode="r", encoding="utf-8") as tokenfile:
             authtoken = tokenfile.read().strip()
 
-        arch = Archivist(args.url, authtoken)
+        arch = Archivist(
+            args.url,
+            authtoken,
+            partner_id=args.partner_id,
+            user_agent=f"{USER_AGENT_PREFIX}{VERSION}",
+        )
 
     if arch is None:
         LOGGER.error("Critical error.  Aborting.")

--- a/archivist_samples/testing/constants.py
+++ b/archivist_samples/testing/constants.py
@@ -1,4 +1,4 @@
 """Constants
 """
 
-USER_AGENT_PREFIX = "datatrails-samples/"
+USER_AGENT_PREFIX = "samples/"

--- a/archivist_samples/testing/constants.py
+++ b/archivist_samples/testing/constants.py
@@ -1,0 +1,4 @@
+"""Constants
+"""
+
+USER_AGENT_PREFIX = "datatrails-samples/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyyaml~=6.0.1
 # the following lines. Also do similar in the Dockerfile.
 # That way one can test an unreleased version of github datatrails-samples.
 # NB dont forget to uncomment before merging !!
-datatrails-archivist==0.31.1
+datatrails-archivist==0.31.2

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -15,6 +15,7 @@ docker run \
     -e TEST_ARCHIVIST \
     -e TEST_AUTHTOKEN_FILENAME \
     -e TEST_NAMESPACE \
+    -e TEST_PARTNER_ID \
     -e TEST_SELECTOR \
     -e TEST_VERBOSE \
     -e GITHUB_REF \

--- a/scripts/functests.sh
+++ b/scripts/functests.sh
@@ -7,15 +7,20 @@
 # Populate the credentials directory with auth token.
 # The auth token must be for a particular tenant identity.
 #
+rm -rf samples-venv
 python3 -m venv samples-venv
 source samples-venv/bin/activate
-python3 -m pip install -q --force-reinstall dist/datatrails_samples-*.whl
+function finalise {
+    deactivate
+    rm -rf samples-venv
+}
+trap finalise EXIT
 
 # do everything in sub directory to ensure that wheel is used and not local code.
-export TEST_AUTHTOKEN_FILENAME=../${TEST_AUTHTOKEN_FILENAME}
-(cd samples-venv && ../scripts/samples.sh functests)
+(export TEST_AUTHTOKEN_FILENAME=../${TEST_AUTHTOKEN_FILENAME} \
+    && cd samples-venv \
+    && python3 -m pip install -q ../dist/datatrails_samples-*.whl \
+    && ../scripts/samples.sh functests)
 
-deactivate
-rm -rf samples-venv
 
 

--- a/scripts/samples.sh
+++ b/scripts/samples.sh
@@ -100,6 +100,11 @@ else
     echo "No NAMESPACE specified - may share assets etc with someone else on same URL"
 fi
 
+if [ -n "$TEST_PARTNER_ID" ]
+then
+    ARGS="$ARGS --partner_id ${TEST_PARTNER_ID}"
+fi
+
 # emit command if executing tests against the docker image or the installed wheel
 command() {
     if [ "${TASK}" == "samples" ]


### PR DESCRIPTION
Additionally fixed faulty functest - ensure that the venv is clean.

[test-results.txt](https://github.com/user-attachments/files/16124576/test-results.txt)

Additionally checked logs from k9s:

      2024-07-08T08:58:44.438Z    INFO    segment/segment.go:106    track event: {   tenant/24cbb99b-46e4-4ad6-a5f9-9502c9eec795_paul-systemtest.jitsuin.com::paul@datatrails.ai API 0001-01-01 │
      │  00:00:00 +0000 UTC <nil> map[DataTrails-Partner-ID:acmecorp DataTrails-User-Agent:samples/v0.17.1-3-g2743f01-dirty pysdk/v0.31.2 Method:GET Path:/archivist/v2/assets Query.attributes.a │
       │ rc_display_type:Door access terminal Query.attributes.arc_namespace:door_entry_21161 Query.page_size:1 Service:assetsv2 tenantID:tenant/24cbb99b-46e4-4ad6-a5f9-9502c9eec795] map[]}    { │
      │ "servicename": "assetsv2"}    
